### PR TITLE
udpate SizePlugin version & add support for bot

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "nodemon": "^1.19.1",
     "nodemon-webpack-plugin": "^4.0.8",
     "npm-run-all": "^4.1.5",
-    "size-plugin": "^1.2.0",
+    "size-plugin": "^2.0.0",
     "source-map-loader": "^0.2.4",
     "webpack": "^4.35.3",
     "webpack-cli": "^3.3.5",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "nodemon": "^1.19.1",
     "nodemon-webpack-plugin": "^4.0.8",
     "npm-run-all": "^4.1.5",
-    "size-plugin": "^2.0.0",
+    "size-plugin": "^2.0.1",
     "source-map-loader": "^0.2.4",
     "webpack": "^4.35.3",
     "webpack-cli": "^3.3.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,7 +43,7 @@ module.exports = {
       verbose: false
     }),
     new DuplicatePackageCheckerPlugin(),
-    new SizePlugin(),
+    new SizePlugin({publish:true}),
     new WebpackBar(),
     new webpack.BannerPlugin({ banner: "#!/usr/bin/env node", raw: true })
   ]


### PR DESCRIPTION
👋
I noticed `repo-genesis-cli` is using [size-plugin](https://github.com/GoogleChromeLabs/size-plugin) .

I have created a [bot](https://github.com/kuldeepkeshwar/size-plugin-bot), which works with  [size-plugin](https://github.com/GoogleChromeLabs/size-plugin) and comments the sizes of the assets and the changes since the last build into the relevant PR

I have done the required configuration in pr (updating `size-plugin@2.0.0` & turn on `publish` flag)

Action item: 
- install [bot](https://github.com/kuldeepkeshwar/size-plugin-bot)